### PR TITLE
Allow for a custom initial buffer

### DIFF
--- a/lib/mote.rb
+++ b/lib/mote.rb
@@ -50,9 +50,9 @@ class Mote
   end
 
   module Helpers
-    def mote(file, params = {}, context = self)
+    def mote(file, params = {}, context = self, buffer = "")
       mote_cache[file] ||= Mote.parse(File.read(file), context, params.keys)
-      mote_cache[file][params]
+      mote_cache[file][params, buffer]
     end
 
     def mote_cache

--- a/test/mote_test.rb
+++ b/test/mote_test.rb
@@ -156,4 +156,8 @@ scope do
       mote("test/foo.mote", {}, TOPLEVEL_BINDING)
     end
   end
+
+  test "passing in a buffer" do
+    assert_equal "barfoo\n", mote("test/foo.mote", {}, self, "bar")
+  end
 end


### PR DESCRIPTION
This allows us passing a buffer that escapes tainted strings by default, reducing the risk of us forgetting to escape user input, for example.
