### PR TITLE
Remove reference to Rake from GemSpec

### DIFF
--- a/mote.gemspec
+++ b/mote.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
     "LICENSE",
     "AUTHORS",
     "README.md",
-    "Rakefile",
     "lib/**/*.rb",
     "*.gemspec",
     "test/**/*.rb"


### PR DESCRIPTION
I believe the reference to `Rake` is unnecessary due to the switch to `make` in d486105c13832c6f89116f36d91047ef73bf8a8d